### PR TITLE
Legger til mark for filopplasting i Sanity

### DIFF
--- a/sanity/schemas/blockContent.js
+++ b/sanity/schemas/blockContent.js
@@ -1,3 +1,5 @@
+import { FaFile } from "react-icons/fa";
+
 export default {
   name: "blockContent",
   title: "Block content",
@@ -16,6 +18,16 @@ export default {
         decorators: [
           { title: "Strong", value: "strong" },
           { title: "Emphasis", value: "em" },
+        ],
+        annotations: [
+          {
+            title: "Filopplasting",
+            name: "filopplasting",
+            type: "file",
+            blockEditor: {
+              icon: FaFile,
+            },
+          },
         ],
       },
     },

--- a/sanity/schemas/filopplasting.js
+++ b/sanity/schemas/filopplasting.js
@@ -1,0 +1,13 @@
+export default {
+  name: "filopplasting",
+  title: "Filopplasting",
+  type: "file",
+  fields: [
+    {
+      name: "title",
+      title: "Title",
+      type: "string",
+      validation: (Rule) => Rule.required(),
+    },
+  ],
+};

--- a/sanity/schemas/schema.js
+++ b/sanity/schemas/schema.js
@@ -9,6 +9,7 @@ import forfatter from "./forfatter";
 import metadata from "./metadata";
 import video from "./video";
 import tilleggsStilling from "./tilleggsStilling";
+import filopplasting from "./filopplasting";
 
 export default createSchema({
   name: "default",
@@ -17,6 +18,7 @@ export default createSchema({
     artikkel,
     bilde,
     blogpost,
+    filopplasting,
     forfatter,
     metadata,
     video,

--- a/src/components/BlockContent.tsx
+++ b/src/components/BlockContent.tsx
@@ -6,6 +6,7 @@ import ArtikkelBilde from "./ArtikkelBilde";
 import Code from "./Code/Code";
 import { navFrontend } from "../styles/navFarger";
 import { fontSize, headerStyles } from "../styles/TypografiNyttDesign";
+import FilopplastingLenke from "./FilopplastingLenke";
 
 const StyledSanityBlockContent = styled(SanityBlockContent)`
   font-weight: 400;
@@ -53,6 +54,9 @@ const StyledSanityBlockContent = styled(SanityBlockContent)`
 `;
 
 const serializers = {
+  marks: {
+    filopplasting: FilopplastingLenke,
+  },
   types: {
     bilde: ArtikkelBilde,
     code: Code,

--- a/src/components/FilopplastingLenke.tsx
+++ b/src/components/FilopplastingLenke.tsx
@@ -1,0 +1,10 @@
+interface Props {
+  mark: { url: string; filename: string };
+  children: React.ReactChild;
+}
+
+function FilopplastingLenke(props: Props) {
+  return <a href={`${props.mark.url}?dl=${props.mark.filename}`}>{props.children}</a>;
+}
+
+export default FilopplastingLenke;

--- a/src/pages/blogg/[slug].tsx
+++ b/src/pages/blogg/[slug].tsx
@@ -35,7 +35,16 @@ const blogQuery = groq`
     tittel,
     _createdAt,
     mainImage,
-    body,
+    body[]{
+      ...,
+      markDefs[]{
+        ...,
+        _type == 'filopplasting' => {
+        	"url": @.asset->url,
+          "filename": @.asset->originalFilename,
+      	}
+      }
+    },
     "slug": slug.current,
     language,
     forfattere[]-> {


### PR DESCRIPTION
Legger inn opplasting av filer i BlockContent. Rendres som vanlig lenke med `?dl=<filename>` fra sanity sin CDN.

![Screenshot 2021-06-08 at 12 28 16](https://user-images.githubusercontent.com/7832273/121170100-0bc27200-c855-11eb-94b8-a0f86a2ccd3d.png)
