### PR TITLE
Fix/fjern cookie info fra serp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ dist
 tsconfig.tsbuildinfo
 
 .yarn
+
+#asdf
+.tool-versions

--- a/src/components/cookieConsent/CookieConsentBanner.tsx
+++ b/src/components/cookieConsent/CookieConsentBanner.tsx
@@ -19,7 +19,7 @@ export const CookieConsentBanner = () => {
   }
 
   return (
-    <div className={style.consentBannerRoot}>
+    <div className={style.consentBannerRoot} data-nosnippet>
       <section aria-labelledby="cookie_heading" className={style.consentBannerSection}>
         <h2 id="cookie_heading" className={style.consentBannerBrandedText}>
           Informasjons


### PR DESCRIPTION
- Legg til `data-nosnippet` som attribute til `<CookieConsentBanner />`for å unngå at innholdet blir del av serp
- Legg til .tool-versions i .gitignore for asdf-brukere