### PR TITLE
- Fjern minimumshøyde og reduser padding for panel-component

### DIFF
--- a/src/components/Panel.module.css
+++ b/src/components/Panel.module.css
@@ -1,7 +1,6 @@
 .panel {
   background-color: var(--background-color);
-  min-height: 110vh;
-  padding: 20vmin 5vmin;
+  padding: 5vmin 5vmin;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
- Jeg synes nettsiden er litt vel luftig og etter hva jeg kan se er det ikke noen grunn for minimumshøyde på 110vh. 